### PR TITLE
Remove chatTutorial help box

### DIFF
--- a/app/assets/javascripts/tutorial.js
+++ b/app/assets/javascripts/tutorial.js
@@ -134,7 +134,11 @@ $(function() {
 		  });
 
 		  gon.doneTutAddFriend = true;
-		  chatTutorial();
+
+		  // Commenting out the line of code below will reenable the chat tutorial help box.
+		  // chatTutorial();
+
+          $('#tutorialFinish').modal('show');
 		});
 	}
 
@@ -161,7 +165,6 @@ $(function() {
 	}
 
 	function chatTutorial() {
-		$('#tutorialFinish').modal('show');
 	    $('#chat-tooltip').tooltip({
 	        html: true,
 	        trigger: 'manual',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,11 +80,11 @@ class ApplicationController < ActionController::Base
   end
   
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) do |u|
+    devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(:username, :email, :password, :password_confirmation, :passcode)
     end
     # devise_parameter_sanitizer.for(:account_update) << :username
-    devise_parameter_sanitizer.for(:account_update) do |u|
+    devise_parameter_sanitizer.permit(:account_update) do |u|
       u.permit(:username, :email, :password, :password_confirmation, :passcode)
     end
   end


### PR DESCRIPTION
Removes the help overlay that appears after a user signs up.
![screen shot 2017-04-24 at 4 06 22 pm](https://cloud.githubusercontent.com/assets/5661818/25366158/ac7e3188-2922-11e7-8cc0-47a7d535fe58.png)
