### PR TITLE
Fix appear online bug and friends filter

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,11 +83,11 @@ class User < ActiveRecord::Base
 
   def online?
     # if signed in
-    if current_sign_in_at.present? 
+    if current_sign_in_at.present?
       online_status = last_sign_out_at.present? ? current_sign_in_at > last_sign_out_at : true
       if (online_status.present?)
       # logger.debug "*****************************"
-      # logger.debug "****** #{online_status} ******" 
+      # logger.debug "****** #{online_status} ******"
       # logger.debug " #{self.appear_offline} ******"
       # logger.debug " #{profile.online} ******"
       # logger.debug "*****************************"

--- a/app/views/conversations/_friend_list.html.erb
+++ b/app/views/conversations/_friend_list.html.erb
@@ -25,7 +25,7 @@
           <% end %>
         </div>
       </div>
-      <!-- <div class="tab-pane custom-scroll friend-scroll" id="peer-counselors">
+      <div class="tab-pane custom-scroll friend-scroll" id="peer-counselors">
         <div class="ui list">
           <% User.peer_counselors.each do |counselor| %>
             <div class="chat-box horizontal-align <%= "active-conversation" if @conversation && @conversation.same_convo?(current_user.id, counselor.id) %>">
@@ -33,7 +33,7 @@
             </div>
           <% end %>
         </div>
-      </div> -->
+      </div>
       <div class="tab-pane custom-scroll friend-scroll" id="online-friends">
         <div class="ui list">
           <% if current_user.online_friends.empty? %>


### PR DESCRIPTION
Friends filter in chat now properly filters based on "All", "Counselors", and "Online". This PR also includes a fix for the small appear online circle. Previously, it would incorrectly show that everyone was offline.